### PR TITLE
Enforce preferred aliases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Dict"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
     "cSpell.words": [
         "Dict",
+        "Tuple",
+        "Tupled",
         "foldl"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
-        "Dict"
+        "Dict",
+        "foldl"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ import Review.Rule exposing (Rule)
 config : List Rule
 config =
     [ NoInconsistentAliases.config
-        [ ( [ "Html", "Attributes" ], "Attr" )
-        , ( [ "Json", "Decode" ], "Decode" )
-        , ( [ "Json", "Encode" ], "Encode" )
+        [ ( "Html.Attributes", "Attr" )
+        , ( "Json.Decode", "Decode" )
+        , ( "Json.Encode", "Encode" )
         ]
         |> NoInconsistentAliases.rule
     ]

--- a/README.md
+++ b/README.md
@@ -5,4 +5,25 @@
 ![elm 0.19](https://img.shields.io/badge/elm-0.19-%231293D8)
 ![Tests](https://github.com/sparksp/elm-review-always/workflows/Tests/badge.svg)
 
-Coming Soon! An [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) rule to enforce consistent import aliases.
+An [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) rule to enforce consistent import aliases.
+
+## Provided Rule
+
+- [`NoInconsistentAliases`](https://package.elm-lang.org/packages/sparksp/elm-review-ports/latest/NoUnusedPorts) - enforce consistent aliases.
+
+## Example Configuration
+
+```elm
+import NoInconsistentAliases
+import Review.Rule exposing (Rule)
+
+config : List Rule
+config =
+    [ NoInconsistentAliases.config
+        [ ( [ "Html", "Attributes" ], "Attr" )
+        , ( [ "Json", "Decode" ], "Decode" )
+        , ( [ "Json", "Encode" ], "Encode" )
+        ]
+        |> NoInconsistentAliases.rule
+    ]
+```

--- a/elm.json
+++ b/elm.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "version": "1.0.0",
     "exposed-modules": [
+        "NoInconsistentAliases"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -13,7 +13,7 @@
             "jfmengels/review-common": "1.0.0",
             "jfmengels/review-debug": "2.0.1",
             "jfmengels/review-unused": "2.0.2",
-            "sparksp/elm-review-camelcase": "1.0.1",
+            "sparksp/elm-review-camelcase": "1.0.2",
             "stil4m/elm-syntax": "7.1.1"
         },
         "indirect": {

--- a/review/src/NoInconsistentAliases
+++ b/review/src/NoInconsistentAliases
@@ -1,0 +1,1 @@
+../../src/NoInconsistentAliases

--- a/review/src/NoInconsistentAliases.elm
+++ b/review/src/NoInconsistentAliases.elm
@@ -1,0 +1,1 @@
+../../src/NoInconsistentAliases.elm

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -15,14 +15,15 @@ import NoDebug.Log
 import NoDebug.TodoOrToString
 import NoExposingEverything
 import NoImportingEverything
+import NoInconsistentAliases
 import NoMissingTypeAnnotation
 import NoUnused.CustomTypeConstructors
 import NoUnused.Dependencies
 import NoUnused.Exports
 import NoUnused.Modules
 import NoUnused.Variables
-import UseCamelCase
 import Review.Rule exposing (Rule)
+import UseCamelCase
 
 
 config : List Rule
@@ -31,6 +32,10 @@ config =
     , NoDebug.TodoOrToString.rule
     , NoExposingEverything.rule
     , NoImportingEverything.rule []
+    , NoInconsistentAliases.config
+        [ ( "Review.Rule", "Rule" )
+        ]
+        |> NoInconsistentAliases.rule
     , NoMissingTypeAnnotation.rule
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.Dependencies.rule

--- a/src/NoInconsistentAliases.elm
+++ b/src/NoInconsistentAliases.elm
@@ -9,7 +9,7 @@ module NoInconsistentAliases exposing (rule, config)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import NoInconsistentAliases.Config as Config exposing (Config)
 import NoInconsistentAliases.Visitor as Visitor
-import Review.Rule as Rule exposing (Rule)
+import Review.Rule exposing (Rule)
 
 
 {-| Ensure consistent use of import aliases throughout your project.

--- a/src/NoInconsistentAliases.elm
+++ b/src/NoInconsistentAliases.elm
@@ -1,0 +1,42 @@
+module NoInconsistentAliases exposing (rule, config)
+
+{-|
+
+@docs rule, config
+
+-}
+
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import NoInconsistentAliases.Config as Config exposing (Config)
+import NoInconsistentAliases.Visitor as Visitor
+import Review.Rule as Rule exposing (Rule)
+
+
+{-| Ensure consistent use of import aliases throughout your project.
+
+    config : List Rule
+    config =
+        [ NoInconsistentAliases.config
+            [ ( [ "Html", "Attributes" ], "Attr" )
+            ]
+            |> NoInconsistentAliases.rule
+        ]
+
+-}
+rule : Config -> Rule
+rule =
+    Visitor.rule
+
+
+{-| Provide a list of preferred names to be enforced. If we find any of the given modules imported with a different alias we will report them.
+
+    NoInconsistentAliases.config
+        [ ( [ "Html", "Attributes" ], "Attr" )
+        , ( [ "Json", "Decode" ], "Decode" )
+        , ( [ "Json", "Encode" ], "Encode" )
+        ]
+
+-}
+config : List ( ModuleName, String ) -> Config
+config =
+    Config.config

--- a/src/NoInconsistentAliases.elm
+++ b/src/NoInconsistentAliases.elm
@@ -6,7 +6,6 @@ module NoInconsistentAliases exposing (rule, config)
 
 -}
 
-import Elm.Syntax.ModuleName exposing (ModuleName)
 import NoInconsistentAliases.Config as Config exposing (Config)
 import NoInconsistentAliases.Visitor as Visitor
 import Review.Rule exposing (Rule)
@@ -17,7 +16,7 @@ import Review.Rule exposing (Rule)
     config : List Rule
     config =
         [ NoInconsistentAliases.config
-            [ ( [ "Html", "Attributes" ], "Attr" )
+            [ ( "Html.Attributes", "Attr" )
             ]
             |> NoInconsistentAliases.rule
         ]
@@ -31,12 +30,12 @@ rule =
 {-| Provide a list of preferred names to be enforced. If we find any of the given modules imported with a different alias we will report them.
 
     NoInconsistentAliases.config
-        [ ( [ "Html", "Attributes" ], "Attr" )
-        , ( [ "Json", "Decode" ], "Decode" )
-        , ( [ "Json", "Encode" ], "Encode" )
+        [ ( "Html.Attributes", "Attr" )
+        , ( "Json.Decode", "Decode" )
+        , ( "Json.Encode", "Encode" )
         ]
 
 -}
-config : List ( ModuleName, String ) -> Config
+config : List ( String, String ) -> Config
 config =
     Config.config

--- a/src/NoInconsistentAliases/BadAlias.elm
+++ b/src/NoInconsistentAliases/BadAlias.elm
@@ -1,6 +1,5 @@
 module NoInconsistentAliases.BadAlias exposing (BadAlias, Name, mapModuleName, mapName, mapUses, new, range, withModuleUse)
 
-import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Range exposing (Range)
 import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
 
@@ -8,7 +7,7 @@ import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
 type BadAlias
     = BadAlias
         { name : Name
-        , moduleName : ModuleName
+        , moduleName : String
         , at : Range
         , uses : List ModuleUse
         }
@@ -18,7 +17,7 @@ type alias Name =
     String
 
 
-new : Name -> ModuleName -> Range -> BadAlias
+new : Name -> String -> Range -> BadAlias
 new newName newModuleName newRange =
     BadAlias
         { name = newName
@@ -43,7 +42,7 @@ mapName mapper (BadAlias alias) =
     mapper alias.name
 
 
-mapModuleName : (ModuleName -> a) -> BadAlias -> a
+mapModuleName : (String -> a) -> BadAlias -> a
 mapModuleName mapper (BadAlias alias) =
     mapper alias.moduleName
 

--- a/src/NoInconsistentAliases/BadAlias.elm
+++ b/src/NoInconsistentAliases/BadAlias.elm
@@ -1,4 +1,4 @@
-module NoInconsistentAliases.BadAlias exposing (BadAlias, Name, mapModuleName, mapName, mapUses, new, range, withModuleUse)
+module NoInconsistentAliases.BadAlias exposing (BadAlias, Name, mapExpectedName, mapModuleName, mapName, mapUses, new, range, withModuleUse)
 
 import Elm.Syntax.Range exposing (Range)
 import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
@@ -8,6 +8,7 @@ type BadAlias
     = BadAlias
         { name : Name
         , moduleName : String
+        , expectedName : String
         , at : Range
         , uses : List ModuleUse
         }
@@ -17,11 +18,12 @@ type alias Name =
     String
 
 
-new : Name -> String -> Range -> BadAlias
-new newName newModuleName newRange =
+new : Name -> String -> String -> Range -> BadAlias
+new newName newModuleName newExpectedName newRange =
     BadAlias
         { name = newName
         , moduleName = newModuleName
+        , expectedName = newExpectedName
         , at = newRange
         , uses = []
         }
@@ -45,6 +47,11 @@ mapName mapper (BadAlias alias) =
 mapModuleName : (String -> a) -> BadAlias -> a
 mapModuleName mapper (BadAlias alias) =
     mapper alias.moduleName
+
+
+mapExpectedName : (String -> a) -> BadAlias -> a
+mapExpectedName mapper (BadAlias alias) =
+    mapper alias.expectedName
 
 
 mapUses : (ModuleUse -> a) -> BadAlias -> List a

--- a/src/NoInconsistentAliases/BadAlias.elm
+++ b/src/NoInconsistentAliases/BadAlias.elm
@@ -1,0 +1,53 @@
+module NoInconsistentAliases.BadAlias exposing (BadAlias, Name, mapModuleName, mapName, mapUses, new, range, withModuleUse)
+
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Range exposing (Range)
+import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
+
+
+type BadAlias
+    = BadAlias
+        { name : Name
+        , moduleName : ModuleName
+        , at : Range
+        , uses : List ModuleUse
+        }
+
+
+type alias Name =
+    String
+
+
+new : Name -> ModuleName -> Range -> BadAlias
+new newName newModuleName newRange =
+    BadAlias
+        { name = newName
+        , moduleName = newModuleName
+        , at = newRange
+        , uses = []
+        }
+
+
+withModuleUse : ModuleUse -> BadAlias -> BadAlias
+withModuleUse moduleUse (BadAlias alias) =
+    BadAlias { alias | uses = moduleUse :: alias.uses }
+
+
+range : BadAlias -> Range
+range (BadAlias alias) =
+    alias.at
+
+
+mapName : (Name -> a) -> BadAlias -> a
+mapName mapper (BadAlias alias) =
+    mapper alias.name
+
+
+mapModuleName : (ModuleName -> a) -> BadAlias -> a
+mapModuleName mapper (BadAlias alias) =
+    mapper alias.moduleName
+
+
+mapUses : (ModuleUse -> a) -> BadAlias -> List a
+mapUses mapper (BadAlias { uses }) =
+    List.map mapper uses

--- a/src/NoInconsistentAliases/BadAliasSet.elm
+++ b/src/NoInconsistentAliases/BadAliasSet.elm
@@ -1,4 +1,4 @@
-module NoInconsistentAliases.BadAliasSet exposing (BadAliasSet, empty, insert, map, use)
+module NoInconsistentAliases.BadAliasSet exposing (BadAliasSet, empty, fold, insert, use)
 
 import Dict exposing (Dict)
 import NoInconsistentAliases.BadAlias as BadAlias exposing (BadAlias)
@@ -33,6 +33,6 @@ use name moduleUse (BadAliasSet aliases) =
             BadAliasSet (Dict.insert name badAliasWithUse aliases)
 
 
-map : (BadAlias -> a) -> BadAliasSet -> List a
-map mapper (BadAliasSet aliases) =
-    aliases |> Dict.values |> List.map mapper
+fold : (BadAlias -> a -> a) -> a -> BadAliasSet -> a
+fold folder start (BadAliasSet aliases) =
+    aliases |> Dict.values |> List.foldl folder start

--- a/src/NoInconsistentAliases/BadAliasSet.elm
+++ b/src/NoInconsistentAliases/BadAliasSet.elm
@@ -1,0 +1,38 @@
+module NoInconsistentAliases.BadAliasSet exposing (BadAliasSet, empty, insert, map, use)
+
+import Dict exposing (Dict)
+import NoInconsistentAliases.BadAlias as BadAlias exposing (BadAlias)
+import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
+
+
+type BadAliasSet
+    = BadAliasSet (Dict BadAlias.Name BadAlias)
+
+
+empty : BadAliasSet
+empty =
+    BadAliasSet Dict.empty
+
+
+insert : BadAlias -> BadAliasSet -> BadAliasSet
+insert badAlias (BadAliasSet aliases) =
+    BadAliasSet (BadAlias.mapName (\name -> Dict.insert name badAlias aliases) badAlias)
+
+
+use : BadAlias.Name -> ModuleUse -> BadAliasSet -> BadAliasSet
+use name moduleUse (BadAliasSet aliases) =
+    case Dict.get name aliases of
+        Nothing ->
+            BadAliasSet aliases
+
+        Just badAlias ->
+            let
+                badAliasWithUse =
+                    BadAlias.withModuleUse moduleUse badAlias
+            in
+            BadAliasSet (Dict.insert name badAliasWithUse aliases)
+
+
+map : (BadAlias -> a) -> BadAliasSet -> List a
+map mapper (BadAliasSet aliases) =
+    aliases |> Dict.values |> List.map mapper

--- a/src/NoInconsistentAliases/Config.elm
+++ b/src/NoInconsistentAliases/Config.elm
@@ -1,4 +1,4 @@
-module NoInconsistentAliases.Config exposing (Config, config, lookupAlias)
+module NoInconsistentAliases.Config exposing (AliasLookup, Config, config, lookupAlias)
 
 import Dict exposing (Dict)
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -6,6 +6,10 @@ import Elm.Syntax.ModuleName exposing (ModuleName)
 
 type Config
     = Aliases (Dict ModuleName String)
+
+
+type alias AliasLookup =
+    String -> Maybe String
 
 
 config : List ( String, String ) -> Config
@@ -16,8 +20,8 @@ config aliases =
         |> Aliases
 
 
-lookupAlias : String -> Config -> Maybe String
-lookupAlias moduleName (Aliases aliases) =
+lookupAlias : Config -> AliasLookup
+lookupAlias (Aliases aliases) moduleName =
     Dict.get (toModuleName moduleName) aliases
 
 

--- a/src/NoInconsistentAliases/Config.elm
+++ b/src/NoInconsistentAliases/Config.elm
@@ -1,4 +1,4 @@
-module NoInconsistentAliases.Config exposing (AliasLookup, Config, config, lookupAlias)
+module NoInconsistentAliases.Config exposing (Config, config, lookupAlias)
 
 import Dict exposing (Dict)
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -6,10 +6,6 @@ import Elm.Syntax.ModuleName exposing (ModuleName)
 
 type Config
     = Aliases (Dict ModuleName String)
-
-
-type alias AliasLookup =
-    String -> Maybe String
 
 
 config : List ( String, String ) -> Config
@@ -20,7 +16,7 @@ config aliases =
         |> Aliases
 
 
-lookupAlias : Config -> AliasLookup
+lookupAlias : Config -> String -> Maybe String
 lookupAlias (Aliases aliases) moduleName =
     Dict.get (toModuleName moduleName) aliases
 

--- a/src/NoInconsistentAliases/Config.elm
+++ b/src/NoInconsistentAliases/Config.elm
@@ -5,14 +5,14 @@ import Elm.Syntax.ModuleName exposing (ModuleName)
 
 
 type Config
-    = Config { aliases : Dict ModuleName String }
+    = Aliases (Dict ModuleName String)
 
 
 config : List ( ModuleName, String ) -> Config
 config aliases =
-    Config { aliases = Dict.fromList aliases }
+    Aliases (Dict.fromList aliases)
 
 
 lookupAlias : ModuleName -> Config -> Maybe String
-lookupAlias moduleName (Config { aliases }) =
+lookupAlias moduleName (Aliases aliases) =
     Dict.get moduleName aliases

--- a/src/NoInconsistentAliases/Config.elm
+++ b/src/NoInconsistentAliases/Config.elm
@@ -8,11 +8,19 @@ type Config
     = Aliases (Dict ModuleName String)
 
 
-config : List ( ModuleName, String ) -> Config
+config : List ( String, String ) -> Config
 config aliases =
-    Aliases (Dict.fromList aliases)
+    aliases
+        |> List.map (Tuple.mapFirst toModuleName)
+        |> Dict.fromList
+        |> Aliases
 
 
-lookupAlias : ModuleName -> Config -> Maybe String
+lookupAlias : String -> Config -> Maybe String
 lookupAlias moduleName (Aliases aliases) =
-    Dict.get moduleName aliases
+    Dict.get (toModuleName moduleName) aliases
+
+
+toModuleName : String -> ModuleName
+toModuleName moduleName =
+    String.split "." moduleName

--- a/src/NoInconsistentAliases/Config.elm
+++ b/src/NoInconsistentAliases/Config.elm
@@ -1,0 +1,18 @@
+module NoInconsistentAliases.Config exposing (Config, config, lookupAlias)
+
+import Dict exposing (Dict)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+
+
+type Config
+    = Config { aliases : Dict ModuleName String }
+
+
+config : List ( ModuleName, String ) -> Config
+config aliases =
+    Config { aliases = Dict.fromList aliases }
+
+
+lookupAlias : ModuleName -> Config -> Maybe String
+lookupAlias moduleName (Config { aliases }) =
+    Dict.get moduleName aliases

--- a/src/NoInconsistentAliases/Context.elm
+++ b/src/NoInconsistentAliases/Context.elm
@@ -1,14 +1,14 @@
 module NoInconsistentAliases.Context exposing
     ( Module, initial
     , addModuleAlias, getModuleForAlias
-    , addBadAlias, mapBadAliases, addModuleCall
+    , addBadAlias, addModuleCall, foldBadAliases
     )
 
 {-|
 
 @docs Module, initial
 @docs addModuleAlias, getModuleForAlias
-@docs addBadAlias, mapBadAliases, addModuleCall
+@docs addBadAlias, addModuleCall, foldBadAliases
 
 -}
 
@@ -52,9 +52,9 @@ addModuleCall moduleAlias function range (Module context) =
         }
 
 
-mapBadAliases : (BadAlias -> a) -> Module -> List a
-mapBadAliases mapper (Module { badAliases }) =
-    BadAliasSet.map mapper badAliases
+foldBadAliases : (BadAlias -> a -> a) -> a -> Module -> a
+foldBadAliases folder start (Module { badAliases }) =
+    BadAliasSet.fold folder start badAliases
 
 
 getModuleForAlias : String -> Module -> Maybe String

--- a/src/NoInconsistentAliases/Context.elm
+++ b/src/NoInconsistentAliases/Context.elm
@@ -1,13 +1,13 @@
 module NoInconsistentAliases.Context exposing
     ( Module, initial
-    , addModuleAlias, getModuleForAlias
+    , addModuleAlias, lookupModuleName, ModuleNameLookup
     , addBadAlias, addModuleCall, foldBadAliases
     )
 
 {-|
 
 @docs Module, initial
-@docs addModuleAlias, getModuleForAlias
+@docs addModuleAlias, lookupModuleName, ModuleNameLookup
 @docs addBadAlias, addModuleCall, foldBadAliases
 
 -}
@@ -24,6 +24,10 @@ type Module
         { aliases : Dict String String
         , badAliases : BadAliasSet
         }
+
+
+type alias ModuleNameLookup =
+    String -> Maybe String
 
 
 initial : Module
@@ -57,6 +61,6 @@ foldBadAliases folder start (Module { badAliases }) =
     BadAliasSet.fold folder start badAliases
 
 
-getModuleForAlias : String -> Module -> Maybe String
-getModuleForAlias moduleAlias (Module { aliases }) =
+lookupModuleName : Module -> ModuleNameLookup
+lookupModuleName (Module { aliases }) moduleAlias =
     Dict.get moduleAlias aliases

--- a/src/NoInconsistentAliases/Context.elm
+++ b/src/NoInconsistentAliases/Context.elm
@@ -1,13 +1,13 @@
 module NoInconsistentAliases.Context exposing
     ( Module, initial
-    , addModuleAlias, lookupModuleName, ModuleNameLookup
+    , addModuleAlias, lookupModuleName
     , addBadAlias, addModuleCall, foldBadAliases
     )
 
 {-|
 
 @docs Module, initial
-@docs addModuleAlias, lookupModuleName, ModuleNameLookup
+@docs addModuleAlias, lookupModuleName
 @docs addBadAlias, addModuleCall, foldBadAliases
 
 -}
@@ -24,10 +24,6 @@ type Module
         { aliases : Dict String String
         , badAliases : BadAliasSet
         }
-
-
-type alias ModuleNameLookup =
-    String -> Maybe String
 
 
 initial : Module
@@ -61,6 +57,6 @@ foldBadAliases folder start (Module { badAliases }) =
     BadAliasSet.fold folder start badAliases
 
 
-lookupModuleName : Module -> ModuleNameLookup
+lookupModuleName : Module -> String -> Maybe String
 lookupModuleName (Module { aliases }) moduleAlias =
     Dict.get moduleAlias aliases

--- a/src/NoInconsistentAliases/Context.elm
+++ b/src/NoInconsistentAliases/Context.elm
@@ -1,0 +1,30 @@
+module NoInconsistentAliases.Context exposing (Module, addBadAlias, addModuleCall, initial, mapBadAliases)
+
+import Elm.Syntax.Range exposing (Range)
+import NoInconsistentAliases.BadAlias as BadAlias exposing (BadAlias)
+import NoInconsistentAliases.BadAliasSet as BadAliasSet exposing (BadAliasSet)
+import NoInconsistentAliases.ModuleUse as ModuleUse
+
+
+type Module
+    = BadAliases BadAliasSet
+
+
+initial : Module
+initial =
+    BadAliases BadAliasSet.empty
+
+
+addBadAlias : BadAlias -> Module -> Module
+addBadAlias badAlias (BadAliases aliases) =
+    BadAliases (BadAliasSet.insert badAlias aliases)
+
+
+addModuleCall : BadAlias.Name -> String -> Range -> Module -> Module
+addModuleCall moduleAlias function range (BadAliases aliases) =
+    BadAliases (BadAliasSet.use moduleAlias (ModuleUse.new function range) aliases)
+
+
+mapBadAliases : (BadAlias -> a) -> Module -> List a
+mapBadAliases mapper (BadAliases aliases) =
+    BadAliasSet.map mapper aliases

--- a/src/NoInconsistentAliases/ModuleUse.elm
+++ b/src/NoInconsistentAliases/ModuleUse.elm
@@ -1,0 +1,22 @@
+module NoInconsistentAliases.ModuleUse exposing (ModuleUse, mapFunction, new, range)
+
+import Elm.Syntax.Range exposing (Range)
+
+
+type ModuleUse
+    = ModuleUse String Range
+
+
+new : String -> Range -> ModuleUse
+new newFunction newRange =
+    ModuleUse newFunction newRange
+
+
+mapFunction : (String -> a) -> ModuleUse -> a
+mapFunction mapper (ModuleUse name _) =
+    mapper name
+
+
+range : ModuleUse -> Range
+range (ModuleUse _ useRange) =
+    useRange

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -1,6 +1,6 @@
 module NoInconsistentAliases.Visitor exposing (rule)
 
-import Elm.Syntax.Import as Import exposing (Import)
+import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import NoInconsistentAliases.Config as Config exposing (Config)

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -66,7 +66,7 @@ rememberBadAlias config moduleName maybeModuleAlias context =
             if expectedAlias /= (moduleAlias |> Node.value) then
                 let
                     badAlias =
-                        BadAlias.new (Node.value moduleAlias) moduleName (Node.range moduleAlias)
+                        BadAlias.new (Node.value moduleAlias) moduleName expectedAlias (Node.range moduleAlias)
                 in
                 context |> Context.addBadAlias badAlias
 
@@ -293,9 +293,7 @@ foldBadAliasError config context badAlias errors =
             badAlias |> BadAlias.mapModuleName identity
 
         expectedAlias =
-            config
-                |> Config.lookupAlias moduleName
-                |> Maybe.withDefault ""
+            badAlias |> BadAlias.mapExpectedName identity
 
         moduleClash =
             detectModuleCollision context moduleName expectedAlias

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -61,6 +61,9 @@ declarationVisitor node context =
         Declaration.FunctionDeclaration { signature } ->
             context |> maybeSignatureVisitor signature
 
+        Declaration.AliasDeclaration { typeAnnotation } ->
+            context |> typeAnnotationVisitor typeAnnotation
+
         _ ->
             context
 

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -1,0 +1,49 @@
+module NoInconsistentAliases.Visitor exposing (rule)
+
+import Elm.Syntax.Import as Import exposing (Import)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import NoInconsistentAliases.Config as Config exposing (Config)
+import Review.Rule as Rule exposing (Error, Rule)
+
+
+rule : Config -> Rule
+rule config =
+    Rule.newModuleRuleSchema "NoInconsistentAliases" ()
+        |> Rule.withSimpleImportVisitor (importVisitor config)
+        |> Rule.fromModuleRuleSchema
+
+
+importVisitor : Config -> Node Import -> List (Error {})
+importVisitor config node =
+    let
+        moduleName =
+            node |> Node.value |> .moduleName |> Node.value
+
+        maybeModuleAlias =
+            node |> Node.value |> .moduleAlias |> Maybe.map (Node.map formatModuleName)
+    in
+    case ( Config.lookupAlias moduleName config, maybeModuleAlias ) of
+        ( Just expectedAlias, Just moduleAlias ) ->
+            if expectedAlias /= (moduleAlias |> Node.value) then
+                [ incorrectAliasError expectedAlias moduleName moduleAlias ]
+
+            else
+                []
+
+        _ ->
+            []
+
+
+incorrectAliasError : String -> ModuleName -> Node String -> Error {}
+incorrectAliasError expectedAlias moduleName wrongAlias =
+    Rule.error
+        { message = "Incorrect alias `" ++ Node.value wrongAlias ++ "` for module `" ++ formatModuleName moduleName ++ "`"
+        , details = [ "This import does not use your preferred alias `" ++ expectedAlias ++ "`." ]
+        }
+        (Node.range wrongAlias)
+
+
+formatModuleName : ModuleName -> String
+formatModuleName moduleName =
+    String.join "." moduleName

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -172,6 +172,9 @@ expressionVisitor node direction context =
         ( Rule.OnEnter, Expression.LetExpression { declarations } ) ->
             ( [], context |> letDeclarationListVisitor declarations )
 
+        ( Rule.OnEnter, Expression.LambdaExpression { args } ) ->
+            ( [], context |> patternListVisitor args )
+
         ( Rule.OnEnter, _ ) ->
             ( [], context )
 

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -1,21 +1,28 @@
 module NoInconsistentAliases.Visitor exposing (rule)
 
+import Elm.Syntax.Expression as Expression exposing (Expression)
 import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
+import NoInconsistentAliases.BadAlias as BadAlias exposing (BadAlias)
 import NoInconsistentAliases.Config as Config exposing (Config)
+import NoInconsistentAliases.Context as Context
+import NoInconsistentAliases.ModuleUse as ModuleUse exposing (ModuleUse)
+import Review.Fix as Fix exposing (Fix)
 import Review.Rule as Rule exposing (Error, Rule)
 
 
 rule : Config -> Rule
 rule config =
-    Rule.newModuleRuleSchema "NoInconsistentAliases" ()
-        |> Rule.withSimpleImportVisitor (importVisitor config)
+    Rule.newModuleRuleSchema "NoInconsistentAliases" Context.initial
+        |> Rule.withImportVisitor (importVisitor config)
+        |> Rule.withExpressionVisitor expressionVisitor
+        |> Rule.withFinalModuleEvaluation (finalEvaluation config)
         |> Rule.fromModuleRuleSchema
 
 
-importVisitor : Config -> Node Import -> List (Error {})
-importVisitor config node =
+importVisitor : Config -> Node Import -> Context.Module -> ( List (Error {}), Context.Module )
+importVisitor config node context =
     let
         moduleName =
             node |> Node.value |> .moduleName |> Node.value
@@ -26,24 +33,79 @@ importVisitor config node =
     case ( Config.lookupAlias moduleName config, maybeModuleAlias ) of
         ( Just expectedAlias, Just moduleAlias ) ->
             if expectedAlias /= (moduleAlias |> Node.value) then
-                [ incorrectAliasError expectedAlias moduleName moduleAlias ]
+                let
+                    badAlias =
+                        BadAlias.new (Node.value moduleAlias) moduleName (Node.range moduleAlias)
+                in
+                ( [], Context.addBadAlias badAlias context )
 
             else
-                []
+                ( [], context )
 
         _ ->
-            []
+            ( [], context )
 
 
-incorrectAliasError : String -> ModuleName -> Node String -> Error {}
-incorrectAliasError expectedAlias moduleName wrongAlias =
-    Rule.error
-        { message = "Incorrect alias `" ++ Node.value wrongAlias ++ "` for module `" ++ formatModuleName moduleName ++ "`"
-        , details = [ "This import does not use your preferred alias `" ++ expectedAlias ++ "`." ]
+expressionVisitor : Node Expression -> Rule.Direction -> Context.Module -> ( List (Error {}), Context.Module )
+expressionVisitor node direction context =
+    case ( direction, Node.value node ) of
+        ( Rule.OnEnter, Expression.FunctionOrValue [ moduleAlias ] function ) ->
+            ( [], Context.addModuleCall moduleAlias function (Node.range node) context )
+
+        ( Rule.OnEnter, _ ) ->
+            ( [], context )
+
+        ( Rule.OnExit, _ ) ->
+            ( [], context )
+
+
+finalEvaluation : Config -> Context.Module -> List (Error {})
+finalEvaluation config context =
+    Context.mapBadAliases (incorrectAliasError config) context
+
+
+incorrectAliasError : Config -> BadAlias -> Error {}
+incorrectAliasError config badAlias =
+    let
+        expectedAlias =
+            BadAlias.mapModuleName (\name -> Config.lookupAlias name config) badAlias
+                |> Maybe.withDefault ""
+
+        badRange =
+            BadAlias.range badAlias
+
+        fixModuleAlias =
+            Fix.replaceRangeBy badRange expectedAlias
+
+        fixModuleUses =
+            BadAlias.mapUses (fixModuleUse expectedAlias) badAlias
+    in
+    Rule.errorWithFix
+        { message = incorrectAliasMessage badAlias
+        , details = [ "This import does not use your preferred alias " ++ quote expectedAlias ++ "." ]
         }
-        (Node.range wrongAlias)
+        badRange
+        (fixModuleAlias :: fixModuleUses)
+
+
+incorrectAliasMessage : BadAlias -> String
+incorrectAliasMessage badAlias =
+    "Incorrect alias "
+        ++ BadAlias.mapName quote badAlias
+        ++ " for module "
+        ++ BadAlias.mapModuleName (formatModuleName >> quote) badAlias
+
+
+fixModuleUse : String -> ModuleUse -> Fix
+fixModuleUse expectedAlias use =
+    Fix.replaceRangeBy (ModuleUse.range use) (ModuleUse.mapFunction (\name -> expectedAlias ++ "." ++ name) use)
 
 
 formatModuleName : ModuleName -> String
 formatModuleName moduleName =
     String.join "." moduleName
+
+
+quote : String -> String
+quote string =
+    "`" ++ string ++ "`"

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -278,19 +278,25 @@ incorrectAliasError config badAlias =
             BadAlias.mapUses (fixModuleUse expectedAlias) badAlias
     in
     Rule.errorWithFix
-        { message = incorrectAliasMessage badAlias
-        , details = [ "This import does not use your preferred alias " ++ quote expectedAlias ++ "." ]
-        }
+        (incorrectAliasMessage expectedAlias badAlias)
         badRange
         (fixModuleAlias :: fixModuleUses)
 
 
-incorrectAliasMessage : BadAlias -> String
-incorrectAliasMessage badAlias =
-    "Incorrect alias "
-        ++ BadAlias.mapName quote badAlias
-        ++ " for module "
-        ++ BadAlias.mapModuleName (formatModuleName >> quote) badAlias
+incorrectAliasMessage : String -> BadAlias -> { message : String, details : List String }
+incorrectAliasMessage expectedAlias badAlias =
+    let
+        moduleName =
+            BadAlias.mapModuleName (formatModuleName >> quote) badAlias
+    in
+    { message =
+        "Incorrect alias " ++ BadAlias.mapName quote badAlias ++ " for module " ++ moduleName
+    , details =
+        [ "This import does not use your preferred alias " ++ quote expectedAlias ++ " for " ++ moduleName ++ "."
+        , "You should update the alias to be consistent with the rest of the project. "
+            ++ "Remember to change all references to the alias in this module too."
+        ]
+    }
 
 
 fixModuleUse : String -> ModuleUse -> Fix

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -6,6 +6,7 @@ import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Signature exposing (Signature)
+import Elm.Syntax.Type as Type
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
 import NoInconsistentAliases.BadAlias as BadAlias exposing (BadAlias)
 import NoInconsistentAliases.Config as Config exposing (Config)
@@ -64,6 +65,9 @@ declarationVisitor node context =
         Declaration.AliasDeclaration { typeAnnotation } ->
             context |> typeAnnotationVisitor typeAnnotation
 
+        Declaration.CustomTypeDeclaration { constructors } ->
+            context |> valueConstructorListVisitor constructors
+
         _ ->
             context
 
@@ -81,6 +85,16 @@ maybeSignatureVisitor maybeNode context =
 signatureVisitor : Node Signature -> Context.Module -> Context.Module
 signatureVisitor node context =
     typeAnnotationVisitor (node |> Node.value |> .typeAnnotation) context
+
+
+valueConstructorListVisitor : List (Node Type.ValueConstructor) -> Context.Module -> Context.Module
+valueConstructorListVisitor list context =
+    List.foldl valueConstructorVisitor context list
+
+
+valueConstructorVisitor : Node Type.ValueConstructor -> Context.Module -> Context.Module
+valueConstructorVisitor node context =
+    context |> typeAnnotationListVisitor (node |> Node.value |> .arguments)
 
 
 typeAnnotationListVisitor : List (Node TypeAnnotation) -> Context.Module -> Context.Module

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -20,7 +20,6 @@ import Review.Rule as Rule exposing (Error, Rule)
 rule : Config -> Rule
 rule config =
     let
-        lookupAlias : Config.AliasLookup
         lookupAlias =
             Config.lookupAlias config
     in
@@ -32,7 +31,7 @@ rule config =
         |> Rule.fromModuleRuleSchema
 
 
-importVisitor : Config.AliasLookup -> Node Import -> Context.Module -> ( List (Error {}), Context.Module )
+importVisitor : AliasLookup -> Node Import -> Context.Module -> ( List (Error {}), Context.Module )
 importVisitor lookupAlias node context =
     let
         moduleName =
@@ -64,7 +63,7 @@ rememberModuleAlias moduleName maybeModuleAlias context =
             context
 
 
-rememberBadAlias : Config.AliasLookup -> String -> Maybe (Node String) -> Context.Module -> Context.Module
+rememberBadAlias : AliasLookup -> String -> Maybe (Node String) -> Context.Module -> Context.Module
 rememberBadAlias lookupAlias moduleName maybeModuleAlias context =
     case ( lookupAlias moduleName, maybeModuleAlias ) of
         ( Just expectedAlias, Just moduleAlias ) ->
@@ -286,17 +285,16 @@ patternVisitor node context =
             context
 
 
-finalEvaluation : Config.AliasLookup -> Context.Module -> List (Error {})
+finalEvaluation : AliasLookup -> Context.Module -> List (Error {})
 finalEvaluation lookupAlias context =
     let
-        lookupModuleName : Context.ModuleNameLookup
         lookupModuleName =
             Context.lookupModuleName context
     in
     context |> Context.foldBadAliases (foldBadAliasError lookupAlias lookupModuleName) []
 
 
-foldBadAliasError : Config.AliasLookup -> Context.ModuleNameLookup -> BadAlias -> List (Error {}) -> List (Error {})
+foldBadAliasError : AliasLookup -> ModuleNameLookup -> BadAlias -> List (Error {}) -> List (Error {})
 foldBadAliasError lookupAlias lookupModuleName badAlias errors =
     let
         moduleName =
@@ -391,3 +389,11 @@ formatModuleName moduleName =
 quote : String -> String
 quote string =
     "`" ++ string ++ "`"
+
+
+type alias AliasLookup =
+    String -> Maybe String
+
+
+type alias ModuleNameLookup =
+    String -> Maybe String

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -31,7 +31,7 @@ importVisitor : Config -> Node Import -> Context.Module -> ( List (Error {}), Co
 importVisitor config node context =
     let
         moduleName =
-            node |> Node.value |> .moduleName |> Node.value
+            node |> Node.value |> .moduleName |> Node.value |> formatModuleName
 
         maybeModuleAlias =
             node |> Node.value |> .moduleAlias |> Maybe.map (Node.map formatModuleName)
@@ -287,7 +287,7 @@ incorrectAliasMessage : String -> BadAlias -> { message : String, details : List
 incorrectAliasMessage expectedAlias badAlias =
     let
         moduleName =
-            BadAlias.mapModuleName (formatModuleName >> quote) badAlias
+            BadAlias.mapModuleName quote badAlias
     in
     { message =
         "Incorrect alias " ++ BadAlias.mapName quote badAlias ++ " for module " ++ moduleName

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -33,6 +33,35 @@ import Html.Attributes as Attr
 main = Html.div [ Attr.class "container" ] []
 """
                         ]
+        , test "reports incorrect aliases in a function signature" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Json.Encode as E
+import Page
+main : Program E.Value Page.Model Page.Msg
+main =
+    Page.program
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Json", "Encode" ], "Encode" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectErrors
+                        [ incorrectAliasError "Encode" "Json.Encode" "E"
+                            |> Review.Test.atExactly { start = { row = 3, column = 23 }, end = { row = 3, column = 24 } }
+                            |> Review.Test.whenFixed
+                                """
+module Main exposing (main)
+import Json.Encode as Encode
+import Page
+main : Program Encode.Value Page.Model Page.Msg
+main =
+    Page.program
+"""
+                        ]
         , test "does not report modules imported with no alias" <|
             \_ ->
                 """

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -1,0 +1,75 @@
+module NoInconsistentAliasesTests exposing (all)
+
+import NoInconsistentAliases as Rule exposing (rule)
+import Review.Test
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "NoInconsistentAliases"
+        [ test "reports incorrect aliases" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Html.Attributes as A
+main = 1"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectErrors
+                        [ incorrectAliasError "Attr" "Html.Attributes" "A"
+                            |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 28 } }
+                        ]
+        , test "does not report modules imported with no alias" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Html.Attributes
+main = 1"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectNoErrors
+        , test "does not report modules with the correct alias" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Html.Attributes as Attr
+main = 1"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectNoErrors
+        , test "does not report modules with no preferred alias" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Json.Encode as E
+main = 1"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectNoErrors
+        ]
+
+
+incorrectAliasError : String -> String -> String -> Review.Test.ExpectedError
+incorrectAliasError expectedAlias moduleName wrongAlias =
+    Review.Test.error
+        { message = "Incorrect alias `" ++ wrongAlias ++ "` for module `" ++ moduleName ++ "`"
+        , details = [ "This import does not use your preferred alias `" ++ expectedAlias ++ "`." ]
+        , under = wrongAlias
+        }

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -324,6 +324,10 @@ incorrectAliasError : String -> String -> String -> Review.Test.ExpectedError
 incorrectAliasError expectedAlias moduleName wrongAlias =
     Review.Test.error
         { message = "Incorrect alias `" ++ wrongAlias ++ "` for module `" ++ moduleName ++ "`"
-        , details = [ "This import does not use your preferred alias `" ++ expectedAlias ++ "`." ]
+        , details =
+            [ "This import does not use your preferred alias `" ++ expectedAlias ++ "` for `" ++ moduleName ++ "`."
+            , "You should update the alias to be consistent with the rest of the project. "
+                ++ "Remember to change all references to the alias in this module too."
+            ]
         , under = wrongAlias
         }

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -173,6 +173,29 @@ expressionVisitor node =
             []
 """
                         ]
+        , test "reports incorrect aliases in function arguments" <|
+            \_ ->
+                """
+module Visitor exposing (getRange)
+import Elm.Syntax.Node as ESN
+getRange ((ESN.Node range _) as node) = range
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Elm", "Syntax", "Node" ], "Node" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectErrors
+                        [ incorrectAliasError "Node" "Elm.Syntax.Node" "ESN"
+                            |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 30 } }
+                            |> Review.Test.whenFixed
+                                """
+module Visitor exposing (getRange)
+import Elm.Syntax.Node as Node
+getRange ((Node.Node range _) as node) = range
+"""
+                        ]
         , test "does not report modules imported with no alias" <|
             \_ ->
                 """

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -93,6 +93,33 @@ main =
     Page.program
 """
                         ]
+        , test "reports incorrect aliases in a custom type constructor" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Json.Encode as E
+import Page
+type JsonValue = JsonValue E.Value
+main = Page.main
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Json", "Encode" ], "Encode" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectErrors
+                        [ incorrectAliasError "Encode" "Json.Encode" "E"
+                            |> Review.Test.atExactly { start = { row = 3, column = 23 }, end = { row = 3, column = 24 } }
+                            |> Review.Test.whenFixed
+                                """
+module Main exposing (main)
+import Json.Encode as Encode
+import Page
+type JsonValue = JsonValue Encode.Value
+main = Page.main
+"""
+                        ]
         , test "does not report modules imported with no alias" <|
             \_ ->
                 """

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -62,6 +62,37 @@ main =
     Page.program
 """
                         ]
+        , test "reports incorrect aliases in a type alias" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Json.Encode as E
+import Page
+type alias JsonValue = E.Value
+main : Program JsonValue Page.Model Page.Msg
+main =
+    Page.program
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( [ "Json", "Encode" ], "Encode" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectErrors
+                        [ incorrectAliasError "Encode" "Json.Encode" "E"
+                            |> Review.Test.atExactly { start = { row = 3, column = 23 }, end = { row = 3, column = 24 } }
+                            |> Review.Test.whenFixed
+                                """
+module Main exposing (main)
+import Json.Encode as Encode
+import Page
+type alias JsonValue = Encode.Value
+main : Program JsonValue Page.Model Page.Msg
+main =
+    Page.program
+"""
+                        ]
         , test "does not report modules imported with no alias" <|
             \_ ->
                 """

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -12,8 +12,10 @@ all =
             \_ ->
                 """
 module Main exposing (main)
+import Html
 import Html.Attributes as A
-main = 1"""
+main = Html.div [ A.class "container" ] []
+"""
                     |> Review.Test.run
                         (Rule.config
                             [ ( [ "Html", "Attributes" ], "Attr" )
@@ -22,7 +24,14 @@ main = 1"""
                         )
                     |> Review.Test.expectErrors
                         [ incorrectAliasError "Attr" "Html.Attributes" "A"
-                            |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 28 } }
+                            |> Review.Test.atExactly { start = { row = 4, column = 27 }, end = { row = 4, column = 28 } }
+                            |> Review.Test.whenFixed
+                                """
+module Main exposing (main)
+import Html
+import Html.Attributes as Attr
+main = Html.div [ Attr.class "container" ] []
+"""
                         ]
         , test "does not report modules imported with no alias" <|
             \_ ->

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -18,7 +18,7 @@ main = Html.div [ A.class "container" ] []
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            [ ( "Html.Attributes", "Attr" )
                             ]
                             |> rule
                         )
@@ -45,7 +45,7 @@ main =
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Json", "Encode" ], "Encode" )
+                            [ ( "Json.Encode", "Encode" )
                             ]
                             |> rule
                         )
@@ -75,7 +75,7 @@ main =
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Json", "Encode" ], "Encode" )
+                            [ ( "Json.Encode", "Encode" )
                             ]
                             |> rule
                         )
@@ -104,7 +104,7 @@ main = Page.main
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Json", "Encode" ], "Encode" )
+                            [ ( "Json.Encode", "Encode" )
                             ]
                             |> rule
                         )
@@ -136,8 +136,8 @@ expressionVisitor node =
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Elm", "Syntax", "Expression" ], "Expression" )
-                            , ( [ "Elm", "Syntax", "Node" ], "Node" )
+                            [ ( "Elm.Syntax.Expression", "Expression" )
+                            , ( "Elm.Syntax.Node", "Node" )
                             ]
                             |> rule
                         )
@@ -182,7 +182,7 @@ getRange ((ESN.Node range _) as node) = range
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Elm", "Syntax", "Node" ], "Node" )
+                            [ ( "Elm.Syntax.Node", "Node" )
                             ]
                             |> rule
                         )
@@ -214,7 +214,7 @@ shiftRange input _ _ =
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Elm", "Syntax", "Node" ], "Node" )
+                            [ ( "Elm.Syntax.Node", "Node" )
                             ]
                             |> rule
                         )
@@ -249,8 +249,8 @@ visitor list =
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Elm", "Syntax", "Node" ], "Node" )
-                            , ( [ "Review", "Rule" ], "Rule" )
+                            [ ( "Elm.Syntax.Node", "Node" )
+                            , ( "Review.Rule", "Rule" )
                             ]
                             |> rule
                         )
@@ -286,7 +286,7 @@ import Html.Attributes
 main = 1"""
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            [ ( "Html.Attributes", "Attr" )
                             ]
                             |> rule
                         )
@@ -299,7 +299,7 @@ import Html.Attributes as Attr
 main = 1"""
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            [ ( "Html.Attributes", "Attr" )
                             ]
                             |> rule
                         )
@@ -312,7 +312,7 @@ import Json.Encode as E
 main = 1"""
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Html", "Attributes" ], "Attr" )
+                            [ ( "Html.Attributes", "Attr" )
                             ]
                             |> rule
                         )

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -124,8 +124,8 @@ main = Page.main
             \_ ->
                 """
 module Visitor exposing (expressionVisitor)
-import Elm.Syntax.Node as ESN
 import Elm.Syntax.Expression as ESE
+import Elm.Syntax.Node as ESN
 expressionVisitor : ESN.Node ESE.Expression -> List (Error {})
 expressionVisitor node =
     case ESN.value node of
@@ -136,38 +136,38 @@ expressionVisitor node =
 """
                     |> Review.Test.run
                         (Rule.config
-                            [ ( [ "Elm", "Syntax", "Node" ], "Node" )
-                            , ( [ "Elm", "Syntax", "Expression" ], "Expression" )
+                            [ ( [ "Elm", "Syntax", "Expression" ], "Expression" )
+                            , ( [ "Elm", "Syntax", "Node" ], "Node" )
                             ]
                             |> rule
                         )
                     |> Review.Test.expectErrors
-                        [ incorrectAliasError "Node" "Elm.Syntax.Node" "ESN"
-                            |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 30 } }
+                        [ incorrectAliasError "Expression" "Elm.Syntax.Expression" "ESE"
+                            |> Review.Test.atExactly { start = { row = 3, column = 33 }, end = { row = 3, column = 36 } }
                             |> Review.Test.whenFixed
                                 """
 module Visitor exposing (expressionVisitor)
-import Elm.Syntax.Node as Node
-import Elm.Syntax.Expression as ESE
-expressionVisitor : Node.Node ESE.Expression -> List (Error {})
-expressionVisitor node =
-    case Node.value node of
-        ESE.FunctionOrValue _ _ ->
-            []
-        _ ->
-            []
-"""
-                        , incorrectAliasError "Expression" "Elm.Syntax.Expression" "ESE"
-                            |> Review.Test.atExactly { start = { row = 4, column = 33 }, end = { row = 4, column = 36 } }
-                            |> Review.Test.whenFixed
-                                """
-module Visitor exposing (expressionVisitor)
-import Elm.Syntax.Node as ESN
 import Elm.Syntax.Expression as Expression
+import Elm.Syntax.Node as ESN
 expressionVisitor : ESN.Node Expression.Expression -> List (Error {})
 expressionVisitor node =
     case ESN.value node of
         Expression.FunctionOrValue _ _ ->
+            []
+        _ ->
+            []
+"""
+                        , incorrectAliasError "Node" "Elm.Syntax.Node" "ESN"
+                            |> Review.Test.atExactly { start = { row = 4, column = 27 }, end = { row = 4, column = 30 } }
+                            |> Review.Test.whenFixed
+                                """
+module Visitor exposing (expressionVisitor)
+import Elm.Syntax.Expression as ESE
+import Elm.Syntax.Node as Node
+expressionVisitor : Node.Node ESE.Expression -> List (Error {})
+expressionVisitor node =
+    case Node.value node of
+        ESE.FunctionOrValue _ _ ->
             []
         _ ->
             []

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -290,7 +290,7 @@ view = div [ A.class "container" ] []
                         (Rule.config
                             [ ( "Html.Attributes", "Attr" )
                             ]
-                            |> Rule.rule
+                            |> rule
                         )
                     |> Review.Test.expectErrors
                         [ aliasCollisionError "Attr" "Html.Attributes" "A" "Svg.Attributes"
@@ -308,12 +308,28 @@ view = div [ A.class "container" ] []
                         (Rule.config
                             [ ( "Html.Attributes", "Attr" )
                             ]
-                            |> Rule.rule
+                            |> rule
                         )
                     |> Review.Test.expectErrors
                         [ aliasCollisionError "Attr" "Html.Attributes" "A" "Attr"
                             |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 28 } }
                         ]
+        , test "does not report when there's a collision with another preferred alias" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html.Attributes as A
+import Svg.Attributes as Attr
+view = div [ A.class "container" ] []
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( "Html.Attributes", "Attr" )
+                            , ( "Svg.Attributes", "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectNoErrors
         , test "does not report modules imported with no alias" <|
             \_ ->
                 """


### PR DESCRIPTION
# NoInconsistentAliases

Ensure consistent use of import aliases throughout your project.

```elm
config : List Rule
config =
    [ NoInconsistentAliases.config
        [ ( "Html.Attributes", "Attr" )
        ]
        |> NoInconsistentAliases.rule
    ]
```

## Config

Provide a list of preferred names to be enforced. If we find any of the given modules imported with a different alias we will report them.

```elm
NoInconsistentAliases.config
    [ ( "Html.Attributes", "Attr" )
    , ( "Json.Decode", "Decode" )
    , ( "Json.Encode", "Encode" )
    ]
```

## Todo
- [x] Review Documentation
- [x] Enforce preferred aliases
- [x] Offer a fix for incorrect aliases (including uses)
- [x] Error Message & **Details**
- [x] Test: Case (NamedPattern)
- [x] Test: Custom type (ValueConstructor, TypeAnnotation)
- [x] Test: Function arguments (Pattern, ParenthesizedPattern, AsPattern)
- [x] Test: Function signature (TypeAnnotation)
- [x] Test: Lambda args (Pattern)
- [x] Test: Let (Expression.LetDestructuring)
- [x] Test: Type alias (TypeAlias, TypeAnnotation)
- [x] Test: Function call via alias (Expression.FunctionOrValue)
- [x] Test: TuplePattern
- [x] Test: UnConsPattern
- [x] Test: ListPattern
- [x] [Collision Detection](https://github.com/sparksp/elm-review-imports/issues/3):
  - [x] Do not offer a fix if another alias is in the way
  - [x] Do not offer a fix if a bare module is in the way
  - [x] Do not report if another preferred alias is in the way

Fixes #4 