### PR TITLE
Enforce use of an alias when one is known

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ![elm package](https://img.shields.io/elm-package/v/sparksp/elm-review-imports)
 ![elm-review 2.0](https://img.shields.io/badge/elm--review-2.0-%231293D8)
 ![elm 0.19](https://img.shields.io/badge/elm-0.19-%231293D8)
-![Tests](https://github.com/sparksp/elm-review-always/workflows/Tests/badge.svg)
+![Tests](https://github.com/sparksp/elm-review-imports/workflows/Tests/badge.svg)
 
 An [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) rule to enforce consistent import aliases.
 
 ## Provided Rule
 
-- [`NoInconsistentAliases`](https://package.elm-lang.org/packages/sparksp/elm-review-ports/latest/NoUnusedPorts) - enforce consistent aliases.
+- [`NoInconsistentAliases`](https://package.elm-lang.org/packages/sparksp/elm-review-imports/latest/NoUnusedPorts) - enforce consistent aliases.
 
 ## Example Configuration
 
@@ -24,6 +24,7 @@ config =
         , ( "Json.Decode", "Decode" )
         , ( "Json.Encode", "Encode" )
         ]
+        |> NoInconsistentAliases.noMissingAliases
         |> NoInconsistentAliases.rule
     ]
 ```

--- a/src/NoInconsistentAliases.elm
+++ b/src/NoInconsistentAliases.elm
@@ -1,8 +1,8 @@
-module NoInconsistentAliases exposing (rule, config)
+module NoInconsistentAliases exposing (rule, config, noMissingAliases)
 
 {-|
 
-@docs rule, config
+@docs rule, config, noMissingAliases
 
 -}
 
@@ -34,8 +34,39 @@ rule =
         , ( "Json.Decode", "Decode" )
         , ( "Json.Encode", "Encode" )
         ]
+        |> NoInconsistentAliases.rule
 
 -}
 config : List ( String, String ) -> Config
 config =
     Config.config
+
+
+{-| If a module is called, ensure that there are no missing aliases.
+
+    NoInconsistentAliases.config
+        [ ( "Html.Attributes", "Attr" )
+        ]
+        |> NoInconsistentAliases.noMissingAliases
+        |> NoInconsistentAliases.rule
+
+
+## Success
+
+    import Html.Attributes exposing (class)
+
+    view =
+        div [ class "flex" ] []
+
+
+## Failure
+
+    import Html.Attributes
+
+    container children =
+        Html.div [ Html.Attributes.class "container" ] children
+
+-}
+noMissingAliases : Config -> Config
+noMissingAliases =
+    Config.noMissingAliases

--- a/src/NoInconsistentAliases.elm
+++ b/src/NoInconsistentAliases.elm
@@ -42,7 +42,7 @@ config =
     Config.config
 
 
-{-| If a module is called, ensure that there are no missing aliases.
+{-| Ensure that imports are aliased if a module is used to qualify a function or type, and has a known alias.
 
     NoInconsistentAliases.config
         [ ( "Html.Attributes", "Attr" )
@@ -51,20 +51,34 @@ config =
         |> NoInconsistentAliases.rule
 
 
-## Success
-
-    import Html.Attributes exposing (class)
-
-    view =
-        div [ class "flex" ] []
-
-
 ## Failure
+
+Here `Html.Attributes` has been used to call `class` and the preferred alias has not been used.
 
     import Html.Attributes
 
-    container children =
-        Html.div [ Html.Attributes.class "container" ] children
+    view children =
+        div [ Html.Attributes.class "container" ] children
+
+
+## Success
+
+Here `Html.Attributes` has been aliased to `Attr` as expected.
+
+    import Html.Attributes as Attr
+
+    view children =
+        div [ Attr.class "container" ] children
+
+
+## Success
+
+Here `class` has been exposed so the alias is not needed.
+
+    import Html.Attributes exposing (class)
+
+    view children =
+        div [ class "container" ] children
 
 -}
 noMissingAliases : Config -> Config

--- a/src/NoInconsistentAliases/Config.elm
+++ b/src/NoInconsistentAliases/Config.elm
@@ -1,24 +1,54 @@
-module NoInconsistentAliases.Config exposing (Config, config, lookupAlias)
+module NoInconsistentAliases.Config exposing
+    ( Config, config, noMissingAliases
+    , canMissAliases, lookupAlias
+    )
+
+{-|
+
+@docs Config, config, noMissingAliases
+@docs canMissAliases, lookupAlias
+
+-}
 
 import Dict exposing (Dict)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 
 
 type Config
-    = Aliases (Dict ModuleName String)
+    = Config
+        { aliases : Dict ModuleName String
+        , allowMissingAliases : Bool
+        }
 
 
 config : List ( String, String ) -> Config
 config aliases =
-    aliases
-        |> List.map (Tuple.mapFirst toModuleName)
-        |> Dict.fromList
-        |> Aliases
+    Config
+        { aliases =
+            aliases
+                |> List.map (Tuple.mapFirst toModuleName)
+                |> Dict.fromList
+        , allowMissingAliases = True
+        }
+
+
+noMissingAliases : Config -> Config
+noMissingAliases (Config cfg) =
+    Config { cfg | allowMissingAliases = False }
+
+
+canMissAliases : Config -> Bool
+canMissAliases (Config cfg) =
+    cfg.allowMissingAliases
 
 
 lookupAlias : Config -> String -> Maybe String
-lookupAlias (Aliases aliases) moduleName =
+lookupAlias (Config { aliases }) moduleName =
     Dict.get (toModuleName moduleName) aliases
+
+
+
+--- HELPERS
 
 
 toModuleName : String -> ModuleName

--- a/src/NoInconsistentAliases/MissingAlias.elm
+++ b/src/NoInconsistentAliases/MissingAlias.elm
@@ -1,0 +1,54 @@
+module NoInconsistentAliases.MissingAlias exposing (MissingAlias, hasUses, mapExpectedName, mapModuleName, mapUses, new, range, withModuleUse)
+
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Range exposing (Range)
+import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
+
+
+type MissingAlias
+    = MissingAlias
+        { moduleName : ModuleName
+        , expectedName : String
+        , at : Range
+        , uses : List ModuleUse
+        }
+
+
+new : ModuleName -> String -> Range -> MissingAlias
+new newModuleName newExpectedName newRange =
+    MissingAlias
+        { moduleName = newModuleName
+        , expectedName = newExpectedName
+        , at = newRange
+        , uses = []
+        }
+
+
+withModuleUse : ModuleUse -> MissingAlias -> MissingAlias
+withModuleUse moduleUse (MissingAlias alias) =
+    MissingAlias { alias | uses = moduleUse :: alias.uses }
+
+
+hasUses : MissingAlias -> Bool
+hasUses (MissingAlias { uses }) =
+    uses /= []
+
+
+mapModuleName : (ModuleName -> a) -> MissingAlias -> a
+mapModuleName mapper (MissingAlias { moduleName }) =
+    mapper moduleName
+
+
+mapExpectedName : (String -> a) -> MissingAlias -> a
+mapExpectedName mapper (MissingAlias { expectedName }) =
+    mapper expectedName
+
+
+mapUses : (ModuleUse -> a) -> MissingAlias -> List a
+mapUses mapper (MissingAlias { uses }) =
+    List.map mapper uses
+
+
+range : MissingAlias -> Range
+range (MissingAlias { at }) =
+    at

--- a/src/NoInconsistentAliases/MissingAliasSet.elm
+++ b/src/NoInconsistentAliases/MissingAliasSet.elm
@@ -1,0 +1,39 @@
+module NoInconsistentAliases.MissingAliasSet exposing (MissingAliasSet, empty, fold, insert, use)
+
+import Dict exposing (Dict)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import NoInconsistentAliases.MissingAlias as MissingAlias exposing (MissingAlias)
+import NoInconsistentAliases.ModuleUse exposing (ModuleUse)
+
+
+type MissingAliasSet
+    = MissingAliasSet (Dict ModuleName MissingAlias)
+
+
+empty : MissingAliasSet
+empty =
+    MissingAliasSet Dict.empty
+
+
+insert : MissingAlias -> MissingAliasSet -> MissingAliasSet
+insert missingAlias (MissingAliasSet aliases) =
+    MissingAliasSet (MissingAlias.mapModuleName (\name -> Dict.insert name missingAlias aliases) missingAlias)
+
+
+use : ModuleName -> ModuleUse -> MissingAliasSet -> MissingAliasSet
+use moduleName moduleUse (MissingAliasSet aliases) =
+    case Dict.get moduleName aliases of
+        Nothing ->
+            MissingAliasSet aliases
+
+        Just missingAlias ->
+            let
+                missingAliasWithUse =
+                    MissingAlias.withModuleUse moduleUse missingAlias
+            in
+            MissingAliasSet (Dict.insert moduleName missingAliasWithUse aliases)
+
+
+fold : (MissingAlias -> a -> a) -> a -> MissingAliasSet -> a
+fold folder start (MissingAliasSet aliases) =
+    aliases |> Dict.values |> List.foldl folder start

--- a/src/NoInconsistentAliases/Visitor/Options.elm
+++ b/src/NoInconsistentAliases/Visitor/Options.elm
@@ -1,0 +1,20 @@
+module NoInconsistentAliases.Visitor.Options exposing (AliasLookup, Options, fromConfig)
+
+import NoInconsistentAliases.Config as Config exposing (Config)
+
+
+type alias Options =
+    { lookupAlias : AliasLookup
+    , canMissAliases : Bool
+    }
+
+
+type alias AliasLookup =
+    String -> Maybe String
+
+
+fromConfig : Config -> Options
+fromConfig config =
+    { lookupAlias = Config.lookupAlias config
+    , canMissAliases = Config.canMissAliases config
+    }

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -8,6 +8,45 @@ import Test exposing (Test, describe, test)
 all : Test
 all =
     describe "NoInconsistentAliases"
+        [ preferredAliasTests
+        , missingAliasTests
+        ]
+
+
+missingAliasTests : Test
+missingAliasTests =
+    Test.concat
+        [ test "reports missing alias when one should be used" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html
+import Html.Attributes
+view = Html.div [ Html.Attributes.class "container" ] []
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( "Html.Attributes", "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectErrors
+                        [ missingAliasError "Attr" "Html.Attributes"
+                            |> Review.Test.atExactly { start = { row = 4, column = 8 }, end = { row = 4, column = 23 } }
+                            |> Review.Test.whenFixed
+                                """
+module Page exposing (view)
+import Html
+import Html.Attributes as Attr
+view = Html.div [ Attr.class "container" ] []
+"""
+                        ]
+        ]
+
+
+preferredAliasTests : Test
+preferredAliasTests =
+    Test.concat
         [ test "reports incorrect aliases" <|
             \_ ->
                 """
@@ -396,4 +435,17 @@ aliasCollisionError expectedAlias moduleName wrongAlias collisionName =
                 ++ "Remember to change all references to the alias in this module too."
             ]
         , under = wrongAlias
+        }
+
+
+missingAliasError : String -> String -> Review.Test.ExpectedError
+missingAliasError expectedAlias moduleName =
+    Review.Test.error
+        { message = "Expected alias `" ++ expectedAlias ++ "` missing for module `" ++ moduleName ++ "`."
+        , details =
+            [ "This import does not use your preferred alias `" ++ expectedAlias ++ "` for `" ++ moduleName ++ "`."
+            , "You should update the alias to be consistent with the rest of the project. "
+                ++ "Remember to change all references to the alias in this module too."
+            ]
+        , under = moduleName
         }

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -41,6 +41,21 @@ import Html.Attributes as Attr
 view = Html.div [ Attr.class "container" ] []
 """
                         ]
+        , test "does not report missing aliases when not used" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html
+import Html.Attributes exposing (class)
+view = Html.div [ class "container" ] []
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( "Html.Attributes", "Attr" )
+                            ]
+                            |> rule
+                        )
+                    |> Review.Test.expectNoErrors
         ]
 
 

--- a/tests/NoInconsistentAliasesTests.elm
+++ b/tests/NoInconsistentAliasesTests.elm
@@ -28,6 +28,7 @@ view = Html.div [ Html.Attributes.class "container" ] []
                         (Rule.config
                             [ ( "Html.Attributes", "Attr" )
                             ]
+                            |> Rule.noMissingAliases
                             |> rule
                         )
                     |> Review.Test.expectErrors
@@ -48,6 +49,22 @@ module Page exposing (view)
 import Html
 import Html.Attributes exposing (class)
 view = Html.div [ class "container" ] []
+"""
+                    |> Review.Test.run
+                        (Rule.config
+                            [ ( "Html.Attributes", "Attr" )
+                            ]
+                            |> Rule.noMissingAliases
+                            |> rule
+                        )
+                    |> Review.Test.expectNoErrors
+        , test "does not report missing aliases when the option is not set" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html
+import Html.Attributes
+view = Html.div [ Html.Attributes.class "container" ] []
 """
                     |> Review.Test.run
                         (Rule.config


### PR DESCRIPTION
Ensure that imports are aliased if a module is used to qualify a function or type, and has a known alias.

```elm
NoInconsistentAliases.config
    [ ( "Html.Attributes", "Attr" )
    ]
    |> NoInconsistentAliases.noMissingAliases
    |> NoInconsistentAliases.rule
```

## Failure

Here `Html.Attributes` has been used to call `class` and the preferred alias has not been used.

```elm
import Html.Attributes

view children =
    div [ Html.Attributes.class "container" ] children
```

## Success

Here `Html.Attributes` has been aliased to `Attr` as expected.

```elm
import Html.Attributes as Attr

view children =
    div [ Attr.class "container" ] children
```

## Success

Here `class` has been exposed so the alias is not needed.

```elm
import Html.Attributes exposing (class)

view children =
    div [ class "container" ] children
```

## Todo

- [x] Documentation
- [x] Configuration
- [x] Report missing alias when one should be used
- [x] Do not report missing alias if the module is not called

Fixes #6 