### PR TITLE
NoModuleOnExposedNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ An [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-review/lat
 ## Provided Rule
 
 - [`NoInconsistentAliases`](https://package.elm-lang.org/packages/sparksp/elm-review-imports/latest/NoUnusedPorts) - enforce consistent aliases.
+- [`NoModuleOnExposedNames`](https://package.elm-lang.org/packages/sparksp/elm-review-imports/latest/NoModuleOnExposedNames) - forbid module on exposed names.
 
 ## Example Configuration
 
 ```elm
 import NoInconsistentAliases
+import NoModuleOnExposedNames
 import Review.Rule exposing (Rule)
 
 config : List Rule
@@ -26,5 +28,6 @@ config =
         ]
         |> NoInconsistentAliases.noMissingAliases
         |> NoInconsistentAliases.rule
+    , NoModuleOnExposedNames.rule
     ]
 ```

--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "version": "1.0.0",
     "exposed-modules": [
-        "NoInconsistentAliases"
+        "NoInconsistentAliases",
+        "NoModuleOnExposedNames"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -10,10 +10,10 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.1",
-            "jfmengels/elm-review": "2.0.1",
+            "jfmengels/elm-review": "2.0.2",
             "jfmengels/review-common": "1.0.0",
             "jfmengels/review-debug": "2.0.1",
-            "jfmengels/review-unused": "2.0.2",
+            "jfmengels/review-unused": "2.0.3",
             "sparksp/elm-review-camelcase": "1.0.2",
             "stil4m/elm-syntax": "7.1.1"
         },

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,21 +1,11 @@
 module ReviewConfig exposing (config)
 
-{-| Do not rename the ReviewConfig module or the config function, because
-`elm-review` will look for these.
-
-To add packages that contain rules, add them to this review project using
-
-    `elm install author/packagename`
-
-when inside the directory containing this file.
-
--}
-
 import NoDebug.Log
 import NoDebug.TodoOrToString
 import NoExposingEverything
 import NoImportingEverything
 import NoInconsistentAliases
+import NoModuleOnExposedNames
 import NoMissingTypeAnnotation
 import NoUnused.CustomTypeConstructors
 import NoUnused.Dependencies
@@ -37,6 +27,7 @@ config =
         ]
         |> NoInconsistentAliases.rule
     , NoMissingTypeAnnotation.rule
+    , NoModuleOnExposedNames.rule
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.Dependencies.rule
     , NoUnused.Exports.rule

--- a/src/NoModuleOnExposedNames.elm
+++ b/src/NoModuleOnExposedNames.elm
@@ -23,13 +23,70 @@ import Vendor.NameVisitor as NameVisitor
         [ NoModuleOnExposedNames.rule
         ]
 
+If a function or type has been exposed on import do not allow it to be called via the module name/alias. You should either remove the call from the import exposes or remove the module name from the call.
+
 
 ## Failure
+
+Here `class` is exposed but is still called by `Attr.class`.
 
     import Html.Attributes as Attr exposing (class)
 
     view children =
         div [ Attr.class "container" ] children
+
+
+## Success
+
+Remove the module name from the call:
+
+    import Html.Attributes as Attr exposing (class)
+
+    view children =
+        div [ class "container" ] children
+
+
+## Success
+
+Or remove `class` from `exposing`:
+
+    import Html.Attributes as Attr
+
+    view children =
+        div [ Attr.class "container" ] children
+
+
+## Failure
+
+Here `Attribute` has been exposed but is still called by `Html.Attribute`.
+
+    import Html exposing (Attribute, Html)
+
+    container : List (Html.Attribute msg) -> List (Html msg) -> Html msg
+    container attributes children =
+        div attributes children
+
+
+## Success
+
+Remove the module name from the call:
+
+    import Html exposing (Attribute, Html)
+
+    container : List (Attribute msg) -> List (Html msg) -> Html msg
+    container attributes children =
+        div attributes children
+
+
+## Success
+
+Or remove `Attribute` from `exposing`:
+
+    import Html exposing (Html)
+
+    container : List (Html.Attribute msg) -> List (Html msg) -> Html msg
+    container attributes children =
+        div attributes children
 
 -}
 rule : Rule

--- a/src/NoModuleOnExposedNames.elm
+++ b/src/NoModuleOnExposedNames.elm
@@ -1,0 +1,95 @@
+module NoModuleOnExposedNames exposing (rule)
+
+{-|
+
+@docs rule
+
+-}
+
+import Elm.Syntax.Expression as Expression exposing (Expression)
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Range exposing (Range)
+import NoModuleOnExposedNames.Context as Context
+import Review.Fix as Fix
+import Review.Rule as Rule exposing (Error, Rule)
+
+
+{-| Forbid modules on names that have been exposed.
+
+    config : List Rule
+    config =
+        [ NoModuleOnExposedNames.rule
+        ]
+
+
+## Failure
+
+    import Html.Attributes as Attr exposing (class)
+
+    view children =
+        div [ Attr.class "container" ] children
+
+-}
+rule : Rule
+rule =
+    Rule.newModuleRuleSchema "NoModuleOnExposedNames" Context.initial
+        |> Rule.withImportVisitor importVisitor
+        |> Rule.withExpressionVisitor expressionVisitor
+        |> Rule.fromModuleRuleSchema
+
+
+importVisitor : Node Import -> Context.Module -> ( List (Error {}), Context.Module )
+importVisitor node context =
+    ( [], context |> rememberExposedNames (Node.value node) )
+
+
+rememberExposedNames : Import -> Context.Module -> Context.Module
+rememberExposedNames { moduleName, moduleAlias, exposingList } context =
+    case exposingList of
+        Nothing ->
+            context
+
+        Just exposes ->
+            let
+                moduleNameOrAlias =
+                    moduleAlias
+                        |> Maybe.map Node.value
+                        |> Maybe.withDefault (Node.value moduleName)
+            in
+            context |> Context.expose moduleNameOrAlias (Node.value exposes)
+
+
+expressionVisitor : Node Expression -> Rule.Direction -> Context.Module -> ( List (Error {}), Context.Module )
+expressionVisitor node direction context =
+    case ( direction, Node.value node ) of
+        ( Rule.OnEnter, Expression.FunctionOrValue [] name ) ->
+            ( [], context )
+
+        ( Rule.OnEnter, Expression.FunctionOrValue moduleName name ) ->
+            if Context.isExposedBy context moduleName name then
+                ( [ moduleOnExposedNameError name (Node.range node) ]
+                , context
+                )
+
+            else
+                ( [], context )
+
+        ( Rule.OnEnter, _ ) ->
+            ( [], context )
+
+        ( Rule.OnExit, _ ) ->
+            ( [], context )
+
+
+moduleOnExposedNameError : String -> Range -> Error {}
+moduleOnExposedNameError name range =
+    Rule.errorWithFix
+        { message = "Module used on exposed name `" ++ name ++ "`."
+        , details =
+            [ "It is not necessary to use the module here as `" ++ name ++ "` was exposed on import."
+            , "You should remove the module from this call, or remove the name from the import .. exposing list."
+            ]
+        }
+        range
+        [ Fix.replaceRangeBy range name ]

--- a/src/NoModuleOnExposedNames/Context.elm
+++ b/src/NoModuleOnExposedNames/Context.elm
@@ -1,0 +1,29 @@
+module NoModuleOnExposedNames.Context exposing (Module, expose, initial, isExposedBy)
+
+import Dict exposing (Dict)
+import Elm.Syntax.Exposing as Exposing exposing (Exposing)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+
+
+type Module
+    = Expose (Dict ModuleName Exposing)
+
+
+initial : Module
+initial =
+    Expose Dict.empty
+
+
+expose : ModuleName -> Exposing -> Module -> Module
+expose moduleName exposer (Expose exposes) =
+    Expose (Dict.insert moduleName exposer exposes)
+
+
+isExposedBy : Module -> ModuleName -> String -> Bool
+isExposedBy (Expose exposes) moduleName name =
+    case Dict.get moduleName exposes of
+        Nothing ->
+            False
+
+        Just exposer ->
+            Exposing.exposesFunction name exposer

--- a/src/NoModuleOnExposedNames/Context.elm
+++ b/src/NoModuleOnExposedNames/Context.elm
@@ -1,8 +1,9 @@
-module NoModuleOnExposedNames.Context exposing (Module, expose, initial, isExposedBy)
+module NoModuleOnExposedNames.Context exposing (Module, expose, initial, isFunctionExposed, isTypeExposed)
 
 import Dict exposing (Dict)
 import Elm.Syntax.Exposing as Exposing exposing (Exposing)
 import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
 
 
 type Module
@@ -19,11 +20,49 @@ expose moduleName exposer (Expose exposes) =
     Expose (Dict.insert moduleName exposer exposes)
 
 
-isExposedBy : Module -> ModuleName -> String -> Bool
-isExposedBy (Expose exposes) moduleName name =
+isFunctionExposed : Module -> ModuleName -> String -> Bool
+isFunctionExposed (Expose exposes) moduleName name =
     case Dict.get moduleName exposes of
         Nothing ->
             False
 
         Just exposer ->
             Exposing.exposesFunction name exposer
+
+
+isTypeExposed : Module -> ModuleName -> String -> Bool
+isTypeExposed (Expose exposes) moduleName name =
+    case Dict.get moduleName exposes of
+        Nothing ->
+            False
+
+        Just (Exposing.All _) ->
+            True
+
+        Just (Exposing.Explicit list) ->
+            List.any (isTypeNamed name) list
+
+
+
+--- HELPERS
+
+
+isTypeNamed : String -> Node Exposing.TopLevelExpose -> Bool
+isTypeNamed name topLevelExpose =
+    (topLevelExpose |> Node.value |> exposingTypeName) == Just name
+
+
+exposingTypeName : Exposing.TopLevelExpose -> Maybe String
+exposingTypeName topLevelExpose =
+    case topLevelExpose of
+        Exposing.FunctionExpose _ ->
+            Nothing
+
+        Exposing.TypeOrAliasExpose name ->
+            Just name
+
+        Exposing.TypeExpose { name } ->
+            Just name
+
+        Exposing.InfixExpose _ ->
+            Nothing

--- a/tests/NoModuleOnExposedNames/ContextTests.elm
+++ b/tests/NoModuleOnExposedNames/ContextTests.elm
@@ -1,0 +1,81 @@
+module NoModuleOnExposedNames.ContextTests exposing (all)
+
+import Elm.Syntax.Exposing as Exposing
+import Elm.Syntax.Node exposing (Node(..))
+import Elm.Syntax.Range as Range
+import Expect
+import NoModuleOnExposedNames.Context as Context
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "NoModuleOnExposedNames.Context"
+        [ describe "isTypeExposed"
+            [ test "is False with no imports" <|
+                \_ ->
+                    Context.isTypeExposed Context.initial [ "Html" ] "Attribute"
+                        |> Expect.equal False
+            , test "is True with Exposing.All" <|
+                \_ ->
+                    let
+                        context =
+                            Context.initial
+                                |> Context.expose [ "Html" ] (Exposing.All Range.emptyRange)
+                    in
+                    Context.isTypeExposed context [ "Html" ] "Attribute"
+                        |> Expect.equal True
+            , test "is True with matching TypeExpose" <|
+                \_ ->
+                    let
+                        context =
+                            Context.initial
+                                |> Context.expose [ "Html" ] (Exposing.Explicit [ typeExpose "Attribute" ])
+                    in
+                    Context.isTypeExposed context [ "Html" ] "Attribute"
+                        |> Expect.equal True
+            , test "is True with matching TypeOrAliasExpose" <|
+                \_ ->
+                    let
+                        context =
+                            Context.initial
+                                |> Context.expose [ "Html" ] (Exposing.Explicit [ typeOrAliasExpose "Attribute" ])
+                    in
+                    Context.isTypeExposed context [ "Html" ] "Attribute"
+                        |> Expect.equal True
+            , test "is False with matching FunctionExpose" <|
+                \_ ->
+                    let
+                        context =
+                            Context.initial
+                                |> Context.expose [ "Html" ] (Exposing.Explicit [ functionExpose "div" ])
+                    in
+                    -- Functions are not types
+                    Context.isTypeExposed context [ "Html" ] "div"
+                        |> Expect.equal False
+            , test "is False with no matching TypeExpose" <|
+                \_ ->
+                    let
+                        context =
+                            Context.initial
+                                |> Context.expose [ "Html" ] (Exposing.Explicit [ typeExpose "Html" ])
+                    in
+                    Context.isTypeExposed context [ "Html" ] "Attribute"
+                        |> Expect.equal False
+            ]
+        ]
+
+
+functionExpose : String -> Node Exposing.TopLevelExpose
+functionExpose name =
+    Node Range.emptyRange (Exposing.FunctionExpose name)
+
+
+typeExpose : String -> Node Exposing.TopLevelExpose
+typeExpose name =
+    Node Range.emptyRange (Exposing.TypeExpose { name = name, open = Nothing })
+
+
+typeOrAliasExpose : String -> Node Exposing.TopLevelExpose
+typeOrAliasExpose name =
+    Node Range.emptyRange (Exposing.TypeOrAliasExpose name)

--- a/tests/NoModuleOnExposedNamesTests.elm
+++ b/tests/NoModuleOnExposedNamesTests.elm
@@ -1,0 +1,52 @@
+module NoModuleOnExposedNamesTests exposing (all)
+
+import NoModuleOnExposedNames exposing (rule)
+import Review.Test
+import Test exposing (Test, describe, test)
+
+
+all : Test
+all =
+    describe "NoModuleOnExposedNames"
+        [ test "reports modules used on exposed names" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html.Attributes as Attr exposing (class)
+view children =
+    div [ Attr.class "container" ] children
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ moduleOnExposedNameError "Attr.class" "class"
+                            |> Review.Test.whenFixed
+                                """
+module Page exposing (view)
+import Html.Attributes as Attr exposing (class)
+view children =
+    div [ class "container" ] children
+"""
+                        ]
+        , test "does not report names not exposed" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html.Attributes as Attr
+view children =
+    div [ Attr.class "container" ] children
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
+        ]
+
+
+moduleOnExposedNameError : String -> String -> Review.Test.ExpectedError
+moduleOnExposedNameError call name =
+    Review.Test.error
+        { message = "Module used on exposed name `" ++ name ++ "`."
+        , details =
+            [ "It is not necessary to use the module here as `" ++ name ++ "` was exposed on import."
+            , "You should remove the module from this call, or remove the name from the import .. exposing list."
+            ]
+        , under = call
+        }

--- a/tests/NoModuleOnExposedNamesTests.elm
+++ b/tests/NoModuleOnExposedNamesTests.elm
@@ -8,7 +8,7 @@ import Test exposing (Test, describe, test)
 all : Test
 all =
     describe "NoModuleOnExposedNames"
-        [ test "reports modules used on exposed names" <|
+        [ test "reports modules used on exposed values" <|
             \_ ->
                 """
 module Page exposing (view)
@@ -18,13 +18,34 @@ view children =
 """
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
-                        [ moduleOnExposedNameError "Attr.class" "class"
+                        [ moduleOnExposedValueError "Attr.class" "class"
                             |> Review.Test.whenFixed
                                 """
 module Page exposing (view)
 import Html.Attributes as Attr exposing (class)
 view children =
     div [ class "container" ] children
+"""
+                        ]
+        , test "reports modules used on exposed types" <|
+            \_ ->
+                """
+module Page exposing (view)
+import Html exposing (Html, Attribute)
+view : List (Html.Attribute msg) -> Html msg
+view children =
+    Html.div [] children
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ moduleOnExposedTypeError "Html.Attribute" "Attribute"
+                            |> Review.Test.whenFixed
+                                """
+module Page exposing (view)
+import Html exposing (Html, Attribute)
+view : List (Attribute msg) -> Html msg
+view children =
+    Html.div [] children
 """
                         ]
         , test "does not report names not exposed" <|
@@ -40,10 +61,22 @@ view children =
         ]
 
 
-moduleOnExposedNameError : String -> String -> Review.Test.ExpectedError
-moduleOnExposedNameError call name =
+moduleOnExposedValueError : String -> String -> Review.Test.ExpectedError
+moduleOnExposedValueError call name =
     Review.Test.error
-        { message = "Module used on exposed name `" ++ name ++ "`."
+        { message = "Module used on exposed value `" ++ name ++ "`."
+        , details =
+            [ "It is not necessary to use the module here as `" ++ name ++ "` was exposed on import."
+            , "You should remove the module from this call, or remove the name from the import .. exposing list."
+            ]
+        , under = call
+        }
+
+
+moduleOnExposedTypeError : String -> String -> Review.Test.ExpectedError
+moduleOnExposedTypeError call name =
+    Review.Test.error
+        { message = "Module used on exposed type `" ++ name ++ "`."
         , details =
             [ "It is not necessary to use the module here as `" ++ name ++ "` was exposed on import."
             , "You should remove the module from this call, or remove the name from the import .. exposing list."


### PR DESCRIPTION
# NoModuleOnExposedNames

Forbid modules on names that have been exposed.

```elm
    config : List Rule
    config =
        [ NoModuleOnExposedNames.rule
        ]
```

## Failure

```elm
import Html.Attributes as Attr exposing (class)

view children =
    div [ Attr.class "container" ] children
```

## Todo

- [x] Documentation
- [x] ValueVisitor
- [x] TypeVisitor

Fixes #8 