### PR TITLE
Add missing elm-review rules

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
         "jfmengels/elm-review": "2.10.0 <= v < 3.0.0",
+        "lue-bird/elm-no-record-type-alias-constructor-function": "1.0.8 <= v < 2.0.0",
         "stil4m/elm-syntax": "7.2.7 <= v < 8.0.0"
     },
     "test-dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "all": "run-s docs lint:* test:* ;",
     "docs": "elm make --docs=docs.json",
     "docs:preview": "elm-doc-preview",
-    "lint:format": "elm-format --yes src tests",
+    "lint:format": "elm-format --yes src tests review/src",
     "lint:review": "elm-review",
     "lint": "run-s lint:* ;",
     "test:elm": "elm-test-rs",

--- a/preview/elm.json
+++ b/preview/elm.json
@@ -11,6 +11,7 @@
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.11.1",
+            "lue-bird/elm-no-record-type-alias-constructor-function": "1.0.8",
             "stil4m/elm-syntax": "7.2.9"
         },
         "indirect": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -17,6 +17,7 @@
             "jfmengels/elm-review-the-elm-architecture": "1.0.3",
             "jfmengels/elm-review-unused": "1.1.29",
             "lue-bird/elm-review-record-alias-constructor": "1.1.2",
+            "mthadley/elm-review-unit": "2.0.2",
             "sparksp/elm-review-always": "1.0.6",
             "sparksp/elm-review-camelcase": "1.1.0",
             "sparksp/elm-review-forbidden-words": "1.0.1",

--- a/review/elm.json
+++ b/review/elm.json
@@ -13,6 +13,7 @@
             "jfmengels/elm-review-common": "1.3.2",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.3",
+            "jfmengels/elm-review-simplify": "2.0.27",
             "jfmengels/elm-review-the-elm-architecture": "1.0.3",
             "jfmengels/elm-review-unused": "1.1.29",
             "sparksp/elm-review-always": "1.0.6",
@@ -37,6 +38,7 @@
             "elm-community/list-extra": "8.7.0",
             "elm-explorations/test": "2.1.0",
             "miniBill/elm-unicode": "1.0.3",
+            "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }

--- a/review/elm.json
+++ b/review/elm.json
@@ -10,6 +10,7 @@
             "elm/json": "1.1.3",
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.12.2",
+            "jfmengels/elm-review-code-style": "1.1.3",
             "jfmengels/elm-review-common": "1.3.2",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.3",

--- a/review/elm.json
+++ b/review/elm.json
@@ -16,6 +16,7 @@
             "jfmengels/elm-review-simplify": "2.0.27",
             "jfmengels/elm-review-the-elm-architecture": "1.0.3",
             "jfmengels/elm-review-unused": "1.1.29",
+            "lue-bird/elm-review-record-alias-constructor": "1.1.2",
             "sparksp/elm-review-always": "1.0.6",
             "sparksp/elm-review-camelcase": "1.1.0",
             "sparksp/elm-review-forbidden-words": "1.0.1",
@@ -28,6 +29,7 @@
             "truqu/elm-review-noredundantcons": "1.0.1"
         },
         "indirect": {
+            "Chadtech/elm-bool-extra": "2.4.2",
             "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
@@ -35,12 +37,16 @@
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
+            "elm-community/basics-extra": "4.1.0",
             "elm-community/list-extra": "8.7.0",
+            "elm-community/maybe-extra": "5.3.0",
             "elm-explorations/test": "2.1.0",
             "miniBill/elm-unicode": "1.0.3",
             "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
-            "stil4m/structured-writer": "1.0.3"
+            "stil4m/structured-writer": "1.0.3",
+            "the-sett/elm-pretty-printer": "3.0.0",
+            "the-sett/elm-syntax-dsl": "6.0.2"
         }
     },
     "test-dependencies": {

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -19,6 +19,8 @@ import NoMissingTypeAnnotation
 import NoMissingTypeAnnotationInLetIn
 import NoMissingTypeExpose
 import NoModuleOnExposedNames
+import NoRecordAliasConstructor
+import NoRecordAliasWithConstructor
 import NoRecursiveUpdate
 import NoRedundantConcat
 import NoRedundantCons
@@ -89,6 +91,8 @@ config =
     , NoMissingTypeAnnotationInLetIn.rule
     , NoMissingTypeExpose.rule
     , NoModuleOnExposedNames.rule
+    , NoRecordAliasConstructor.rule
+    , NoRecordAliasWithConstructor.rule
     , NoRecursiveUpdate.rule
     , NoRedundantConcat.rule
     , NoRedundantCons.rule

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -24,7 +24,9 @@ import NoRecordAliasWithConstructor
 import NoRecursiveUpdate
 import NoRedundantConcat
 import NoRedundantCons
+import NoSimpleLetBody
 import NoUnmatchedUnit
+import NoUnnecessaryTrailingUnderscore
 import NoUnsafePorts
 import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
@@ -97,8 +99,10 @@ config =
     , NoRecursiveUpdate.rule
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
+    , NoSimpleLetBody.rule
     , NoUnmatchedUnit.rule
     , NoUnsafePorts.rule NoUnsafePorts.any
+    , NoUnnecessaryTrailingUnderscore.rule
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.CustomTypeConstructorArgs.rule
     , NoUnused.Dependencies.rule

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -24,6 +24,7 @@ import NoRecordAliasWithConstructor
 import NoRecursiveUpdate
 import NoRedundantConcat
 import NoRedundantCons
+import NoUnmatchedUnit
 import NoUnsafePorts
 import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
@@ -96,6 +97,7 @@ config =
     , NoRecursiveUpdate.rule
     , NoRedundantConcat.rule
     , NoRedundantCons.rule
+    , NoUnmatchedUnit.rule
     , NoUnsafePorts.rule NoUnsafePorts.any
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.CustomTypeConstructorArgs.rule

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -34,6 +34,7 @@ import NoUnused.Variables
 import NoUnusedPorts
 import NoUselessSubscriptions
 import Review.Rule as Rule exposing (Rule)
+import Simplify
 import UseCamelCase
 import Vendor.NoFullyAppliedPrefixOperator as NoFullyAppliedPrefixOperator
 
@@ -102,6 +103,7 @@ config =
     , NoUnusedPorts.rule
     , NoUnused.Variables.rule
     , NoUselessSubscriptions.rule
+    , Simplify.rule Simplify.defaults
     , UseCamelCase.rule UseCamelCase.default
     ]
         |> List.map

--- a/src/NoInconsistentAliases/Visitor.elm
+++ b/src/NoInconsistentAliases/Visitor.elm
@@ -87,9 +87,11 @@ rememberBadAlias { lookupAlias, canMissAliases } (Node moduleNameRange moduleNam
 
 moduleCallVisitor : Node ( ModuleName, String ) -> Context.Module -> ( List (Error {}), Context.Module )
 moduleCallVisitor node context =
-    case Node.value node of
-        ( moduleName, function ) ->
-            ( [], Context.addModuleCall moduleName function (Node.range node) context )
+    let
+        ( moduleName, function ) =
+            Node.value node
+    in
+    ( [], Context.addModuleCall moduleName function (Node.range node) context )
 
 
 finalEvaluation : Options.AliasLookup -> Context.Module -> List (Error {})

--- a/src/NoInconsistentAliases/Visitor/Options.elm
+++ b/src/NoInconsistentAliases/Visitor/Options.elm
@@ -2,12 +2,14 @@ module NoInconsistentAliases.Visitor.Options exposing (AliasLookup, Options, fro
 
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import NoInconsistentAliases.Config as Config exposing (Config)
+import RecordWithoutConstructorFunction exposing (RecordWithoutConstructorFunction)
 
 
 type alias Options =
-    { lookupAlias : AliasLookup
-    , canMissAliases : Bool
-    }
+    RecordWithoutConstructorFunction
+        { lookupAlias : AliasLookup
+        , canMissAliases : Bool
+        }
 
 
 type alias AliasLookup =

--- a/src/NoModuleOnExposedNames.elm
+++ b/src/NoModuleOnExposedNames.elm
@@ -125,28 +125,32 @@ rememberExposedNames { moduleName, moduleAlias, exposingList } context =
 
 valueVisitor : Node ( ModuleName, String ) -> Context.Module -> ( List (Error {}), Context.Module )
 valueVisitor node context =
-    case Node.value node of
-        ( moduleName, name ) ->
-            if Context.isFunctionExposed context moduleName name then
-                ( [ moduleOnExposedValueError name (Node.range node) ]
-                , context
-                )
+    let
+        ( moduleName, name ) =
+            Node.value node
+    in
+    if Context.isFunctionExposed context moduleName name then
+        ( [ moduleOnExposedValueError name (Node.range node) ]
+        , context
+        )
 
-            else
-                ( [], context )
+    else
+        ( [], context )
 
 
 typeVisitor : Node ( ModuleName, String ) -> Context.Module -> ( List (Error {}), Context.Module )
 typeVisitor node context =
-    case Node.value node of
-        ( moduleName, name ) ->
-            if Context.isTypeExposed context moduleName name then
-                ( [ moduleOnExposedTypeError name (Node.range node) ]
-                , context
-                )
+    let
+        ( moduleName, name ) =
+            Node.value node
+    in
+    if Context.isTypeExposed context moduleName name then
+        ( [ moduleOnExposedTypeError name (Node.range node) ]
+        , context
+        )
 
-            else
-                ( [], context )
+    else
+        ( [], context )
 
 
 moduleOnExposedValueError : String -> Range -> Error {}

--- a/tests/Tests/NoInconsistentAliases.elm
+++ b/tests/Tests/NoInconsistentAliases.elm
@@ -16,7 +16,7 @@ all =
 noMissingAliasesTests : List Test
 noMissingAliasesTests =
     [ test "reports missing alias when one should be used" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (view)
 import Html
@@ -42,7 +42,7 @@ view = Html.div [ Attr.class "container" ] []
 """
                     ]
     , test "does not report missing aliases when not used" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (view)
 import Html
@@ -58,7 +58,7 @@ view = Html.div [ class "container" ] []
                     )
                 |> Review.Test.expectNoErrors
     , test "does not report missing aliases when the option is not set" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (view)
 import Html
@@ -78,7 +78,7 @@ view = Html.div [ Html.Attributes.class "container" ] []
 preferredAliasTests : List Test
 preferredAliasTests =
     [ test "reports incorrect aliases" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Html
@@ -103,7 +103,7 @@ main = Html.div [ Attr.class "container" ] []
 """
                     ]
     , test "fixes incorrect aliases in a function signature" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Json.Encode as E
@@ -132,7 +132,7 @@ main =
 """
                     ]
     , test "fixes incorrect aliases in a type alias" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Json.Encode as E
@@ -163,7 +163,7 @@ main =
 """
                     ]
     , test "fixes incorrect aliases in a custom type constructor" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Json.Encode as E
@@ -190,7 +190,7 @@ main = Page.main
 """
                     ]
     , test "fixes incorrect aliases in case expressions" <|
-        \_ ->
+        \() ->
             """
 module Visitor exposing (expressionVisitor)
 import Elm.Syntax.Expression as ESE
@@ -243,7 +243,7 @@ expressionVisitor node =
 """
                     ]
     , test "fixes incorrect aliases nested in case expressions" <|
-        \_ ->
+        \() ->
             """
 module Visitor exposing (expressionVisitor)
 import Elm.Syntax.Expression as ESE
@@ -296,7 +296,7 @@ expressionVisitor node =
 """
                     ]
     , test "fixes incorrect aliases in function arguments" <|
-        \_ ->
+        \() ->
             """
 module Visitor exposing (getRange)
 import Elm.Syntax.Node as ESN
@@ -319,7 +319,7 @@ getRange ((Node.Node range _) as node) = range
 """
                     ]
     , test "fixes incorrect aliases in let blocks" <|
-        \_ ->
+        \() ->
             """
 module Visitor exposing (shiftRange)
 import Elm.Syntax.Node as ESN
@@ -360,7 +360,7 @@ shiftRange input _ _ =
 """
                     ]
     , test "fixes incorrect aliases in a lambda function" <|
-        \_ ->
+        \() ->
             """
 module NoCode exposing (visitor)
 import Elm.Syntax.Node as ESN
@@ -401,7 +401,7 @@ visitor list =
 """
                     ]
     , test "does not offer a fix when there's an alias collision" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (view)
 import Html.Attributes as A
@@ -419,7 +419,7 @@ view = div [ A.class "container" ] []
                         |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 28 } }
                     ]
     , test "does not offer a fix when there's a module collision" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (view)
 import Html.Attributes as A
@@ -437,7 +437,7 @@ view = div [ A.class "container" ] []
                         |> Review.Test.atExactly { start = { row = 3, column = 27 }, end = { row = 3, column = 28 } }
                     ]
     , test "does not report when there's a collision with another preferred alias" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (view)
 import Html.Attributes as A
@@ -453,7 +453,7 @@ view = div [ A.class "container" ] []
                     )
                 |> Review.Test.expectNoErrors
     , test "does not report modules imported with no alias" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Html.Attributes
@@ -466,7 +466,7 @@ main = 1"""
                     )
                 |> Review.Test.expectNoErrors
     , test "does not report modules with the correct alias" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Html.Attributes as Attr
@@ -479,7 +479,7 @@ main = 1"""
                     )
                 |> Review.Test.expectNoErrors
     , test "does not report modules with no preferred alias" <|
-        \_ ->
+        \() ->
             """
 module Main exposing (main)
 import Json.Encode as E

--- a/tests/Tests/NoModuleOnExposedNames.elm
+++ b/tests/Tests/NoModuleOnExposedNames.elm
@@ -9,7 +9,7 @@ all : Test
 all =
     describe "NoModuleOnExposedNames"
         [ test "reports modules used on exposed values" <|
-            \_ ->
+            \() ->
                 """
 module Page exposing (view)
 import Html.Attributes as Attr exposing (class)
@@ -28,7 +28,7 @@ view children =
 """
                         ]
         , test "reports modules used on exposed types" <|
-            \_ ->
+            \() ->
                 """
 module Page exposing (view)
 import Html exposing (Html, Attribute)
@@ -49,7 +49,7 @@ view children =
 """
                         ]
         , test "does not report names not exposed" <|
-            \_ ->
+            \() ->
                 """
 module Page exposing (view)
 import Html.Attributes as Attr

--- a/tests/Tests/NoModuleOnExposedNames/Context.elm
+++ b/tests/Tests/NoModuleOnExposedNames/Context.elm
@@ -13,11 +13,11 @@ all =
     describe "NoModuleOnExposedNames.Context"
         [ describe "isTypeExposed"
             [ test "is False with no imports" <|
-                \_ ->
+                \() ->
                     Context.isTypeExposed Context.initial [ "Html" ] "Attribute"
                         |> Expect.equal False
             , test "is True with Exposing.All" <|
-                \_ ->
+                \() ->
                     let
                         context : Context.Module
                         context =
@@ -27,7 +27,7 @@ all =
                     Context.isTypeExposed context [ "Html" ] "Attribute"
                         |> Expect.equal True
             , test "is True with matching TypeExpose" <|
-                \_ ->
+                \() ->
                     let
                         context : Context.Module
                         context =
@@ -37,7 +37,7 @@ all =
                     Context.isTypeExposed context [ "Html" ] "Attribute"
                         |> Expect.equal True
             , test "is True with matching TypeOrAliasExpose" <|
-                \_ ->
+                \() ->
                     let
                         context : Context.Module
                         context =
@@ -47,7 +47,7 @@ all =
                     Context.isTypeExposed context [ "Html" ] "Attribute"
                         |> Expect.equal True
             , test "is False with matching FunctionExpose" <|
-                \_ ->
+                \() ->
                     let
                         context : Context.Module
                         context =
@@ -58,7 +58,7 @@ all =
                     Context.isTypeExposed context [ "Html" ] "div"
                         |> Expect.equal False
             , test "is False with no matching TypeExpose" <|
-                \_ ->
+                \() ->
                     let
                         context : Context.Module
                         context =

--- a/tests/Tests/Vendor/NameVisitor.elm
+++ b/tests/Tests/Vendor/NameVisitor.elm
@@ -438,7 +438,7 @@ view page =
 contextTests : List Test
 contextTests =
     [ test "mutates context" <|
-        \_ ->
+        \() ->
             """
 module Page exposing (Page)
 view : Page -> Html msg


### PR DESCRIPTION
- [x] NoRecordAliasConstructor
- [x] NoRecordAliasWithConstructor
- [x] NoSimpleLetBody
- [x] NoUnmatchedUnit
- [x] NoUnnecessaryTrailingUnderscore
- [x] Simplify